### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,4 +44,6 @@ RUN npm i -g udacimak
 # confirm install
 RUN udacimak --help
 
+WORKDIR /downloads
+
 ENTRYPOINT [ "udacimak" ]


### PR DESCRIPTION
Set the `workdir` to downloads folder otherwise the Downloads go to root path and are not visible on the bind volumes.

# Description

By default any `download` command would save files in the root path of the container. Mounted volumes will see no files on the host. By changing workdir to `/downloads`  this should correctly download to the directory and be visible  on the host path.

Fixes # (issue)
Unfiled issue. Please help to tag if you create an issue.

## Type of change

- [X ] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?
Currently testing the fix. 
`docker container run -it -v "$(pwd)/:/downloads" udacimak/udacimak download [some course id]`
You should now see the downloaded data.
